### PR TITLE
Hook to 'emit' instead of 'after-compile'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function IgnoreAssetsPlugin(options) {
 }
 
 IgnoreAssetsPlugin.prototype.apply = (compiler) => {
-	compiler.plugin('after-compile', (compilation, callback) => {
+	compiler.plugin('emit', (compilation, callback) => {
 		const compiledAssets = _.keys(compilation.assets);
 		ignoredAssets.forEach((element) => {
 			if (_.indexOf(compiledAssets, element) !== -1) {


### PR DESCRIPTION
The idea is to give a chance for other plugins such as `html-webpack-plugin` to handle assets before they are dropped.